### PR TITLE
load my working theme in browser directly

### DIFF
--- a/bin/tasks/serve.js
+++ b/bin/tasks/serve.js
@@ -12,6 +12,7 @@ let sync = require('../service');
 gulp.task('serve', ['build'], () => {
   let bsConfig = config.browser_sync;
   bsConfig.proxy = config.theme[config.env].url;
+  bsConfig.startPath = "/?design_theme_id=" + config.theme[config.env].theme_id;
   browserSync.init(bsConfig);
 
   gulp.watch(config.paths.scss + '**/*.scss', {cwd: './'}, ['scss'])


### PR DESCRIPTION
**edt serve** loads Browsersync with path of my working theme
https://localhost:5000/?design_theme_id=**theme_id**